### PR TITLE
Support for diameter-dictionary module from new diameter 0.9.3 version

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Long = require('long');
-const dictionary = require('diameter/dictionary.json');
+const dictionary = require('diameter-dictionary');
 
 const toCamelMap = {};
 const fromCamelMap = {};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "diameter-avp-object",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Syntactical sugar for manipulating node-diameter AVP arrays",
   "main": "index.js",
   "scripts": {
@@ -20,8 +20,8 @@
   },
   "homepage": "https://github.com/atesgoral/diameter-avp-object#readme",
   "peerDependencies": {
-    "diameter": "^0.9.0",
-    "long": "^3.1.0"
+    "diameter": "^0.9.3",
+    "long": "^3.2.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "diameter-avp-object",
-  "version": "1.0.7",
+  "version": "1.0.6",
   "description": "Syntactical sugar for manipulating node-diameter AVP arrays",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The new version of diameter is using a separate package for dictionary, I've just updated the dependencies to make it work 